### PR TITLE
Switch bootstrap script to uv pip

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -6,7 +6,7 @@ viability analysis simulator.
 1. **Setup the environment**
 
    Run the bootstrap script to create a virtual environment and install
-   dependencies:
+   dependencies using `uv pip`:
 
    ```bash
    bash bootstrap_env.sh

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ source .venv/bin/activate
 ```
 
 The bootstrap script installs dependencies listed in
-`requirements.txt` and produces a `requirements.lock` file with
-pinned versions.
+`requirements.txt` using `uv pip` and produces a `requirements.lock`
+file with pinned versions via `uv pip freeze`.
 
 ## Usage
 

--- a/bootstrap_env.sh
+++ b/bootstrap_env.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Create and configure the Python virtual environment for the PVA simulator.
 # This script uses python3 if python3.12 is unavailable. It installs
-# dependencies from requirements.txt and freezes them into requirements.lock.
+# dependencies from requirements.txt via `uv pip` and freezes them into
+# requirements.lock using `uv pip freeze`.
 
 PYTHON_BIN="python3.12"
 if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
@@ -12,7 +13,7 @@ fi
 source .venv/bin/activate
 
 pip install --upgrade pip
-pip install -r requirements.txt
-pip freeze > requirements.lock
+uv pip install -r requirements.txt
+uv pip freeze > requirements.lock
 
 echo "Virtual environment created using $PYTHON_BIN."


### PR DESCRIPTION
## Summary
- use `uv pip` in bootstrap_env.sh
- mention uv in README installation steps
- mention uv in GETTING_STARTED guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685e8e7fe7e48321bb8f406bbd6847cc