### PR TITLE
Add requirements lock file

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -6,7 +6,8 @@ viability analysis simulator.
 1. **Setup the environment**
 
    Run the bootstrap script to create a virtual environment and install
-   dependencies:
+   dependencies. It also pins the exact package versions to
+   `requirements.lock`:
 
    ```bash
    bash bootstrap_env.sh

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,0 +1,16 @@
+black==25.1.0
+click==8.2.1
+iniconfig==2.1.0
+isort==6.0.1
+mypy==1.16.1
+mypy_extensions==1.1.0
+nodeenv==1.9.1
+packaging==25.0
+pathspec==0.12.1
+platformdirs==4.3.8
+pluggy==1.6.0
+Pygments==2.19.1
+pyright==1.1.402
+pytest==8.4.0
+ruff==0.11.13
+typing_extensions==4.14.0


### PR DESCRIPTION
## Summary
- generate `requirements.lock` with pip freeze
- mention the lock file in the getting started guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685e8e785cec832197da3f9585c539c6