### PR TITLE
Add workflow to check lock file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        run: python -m pip install uv
+      - name: Verify lock file
+        run: |
+          bash bootstrap_env.sh
+          git diff --exit-code requirements.lock
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -q

--- a/bootstrap_env.sh
+++ b/bootstrap_env.sh
@@ -14,6 +14,7 @@ source .venv/bin/activate
 
 pip install --upgrade pip
 uv pip install -r requirements.txt
+# Regenerate the lock file to capture exact installed versions
 uv pip freeze > requirements.lock
 
 echo "Virtual environment created using $PYTHON_BIN."


### PR DESCRIPTION
## Summary
- rebuild requirements.lock during bootstrap
- add GitHub Actions workflow that ensures the lock file is up to date

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q` *(fails: test_catastrophe_deterministic, test_carrying_capacity_deterministic)*

------
https://chatgpt.com/codex/tasks/task_e_685ff2b2b3d88321aaf4f65dfd159913